### PR TITLE
Fixes type error on data declaration

### DIFF
--- a/src/requestCodeGen.ts
+++ b/src/requestCodeGen.ts
@@ -143,11 +143,10 @@ export function requestCodeGen(paths: IPaths, options: ISwaggerOptions): string 
           : ''
         };
 
-          let data = null;
-          ${
+          let data = ${
         parsedParameters && parsedParameters.bodyParameters.length > 0
-          ? 'data = {' + parsedParameters.bodyParameters.join(',') + '}'
-          : ''
+          ? '{' + parsedParameters.bodyParameters.join(',') + '}'
+          : 'null'
         };
 
           ${contentType === 'multipart/form-data' ? formData : ''}


### PR DESCRIPTION
In generated request function,

```ts
//...
let data = null;
data = { ...params['prop'] }
//...
```

Even though the `data` object is declared as `null` type,
it is reassigned the value that has actual type.
I don't know if it is ok on other environments but my ts3.0 project got some errors.