### PR TITLE
Adds support of primitive response types

### DIFF
--- a/src/baseInterfaces.ts
+++ b/src/baseInterfaces.ts
@@ -38,7 +38,8 @@ export interface IRequestMethod {
     [key: string]: {
       description: string
       schema: {
-        '$ref': string
+        '$ref': string,
+        'type': string,
       }
     }
   }

--- a/src/baseInterfaces.ts
+++ b/src/baseInterfaces.ts
@@ -39,7 +39,8 @@ export interface IRequestMethod {
       description: string
       schema: {
         '$ref': string,
-        'type': string,
+        'type'?: string,
+        'items'?: IParameterItems,
       }
     }
   }

--- a/src/requestCodeGen.ts
+++ b/src/requestCodeGen.ts
@@ -114,18 +114,31 @@ export function requestCodeGen(paths: IPaths, options: ISwaggerOptions): string 
         pathReplace = parsedParameters.requestPathReplace
       }
 
+      // 确定响应的类型
+      // It does not allow the schema defined directly, but only the primitive type is allowed. 
       let responseType: string;
-
       if (!v.responses['200'] || !v.responses['200'].schema) {
         responseType = 'any';
       } else if (v.responses['200'].schema.$ref) {
         responseType = refClassName(v.responses['200'].schema.$ref)
       } else {
-        responseType = v.responses[200].schema.type;
-        if (responseType == 'object' || responseType == 'array') {
-          // Direct defining is not supported.
-          responseType = 'any';
+        let checkType = v.responses[200].schema.type;
+        if (!checkType) {
+          // implicit types
+          if (v.responses[200].schema.items) {
+            responseType = 'array';
+          } else { // if (v.responses[200].schema.properties) // actual check
+            responseType = 'object';
+          }
+        } else {
+          responseType = checkType; // string? -> string
         }
+        if (responseType == 'object') {
+          responseType = 'any';
+        } else if (responseType == 'array') {
+          responseType = 'any[]';
+        }
+        // else ... JSON primitive types (string, boolean, number)
       }
 
       // 模版

--- a/src/requestCodeGen.ts
+++ b/src/requestCodeGen.ts
@@ -114,10 +114,19 @@ export function requestCodeGen(paths: IPaths, options: ISwaggerOptions): string 
         pathReplace = parsedParameters.requestPathReplace
       }
 
-      let responseType =
-        v.responses['200'] && v.responses['200'].schema && v.responses['200'].schema.$ref
-          ? refClassName(v.responses['200'].schema.$ref)
-          : 'any'
+      let responseType: string;
+
+      if (!v.responses['200'] || !v.responses['200'].schema) {
+        responseType = 'any';
+      } else if (v.responses['200'].schema.$ref) {
+        responseType = refClassName(v.responses['200'].schema.$ref)
+      } else {
+        responseType = v.responses[200].schema.type;
+        if (responseType == 'object' || responseType == 'array') {
+          // Direct defining is not supported.
+          responseType = 'any';
+        }
+      }
 
       // 模版
       RequestMethods[className] += `


### PR DESCRIPTION
In some cases, we want to use primitive type as just a response data (string, boolean or number).

Example:

```js
// definition of the api "/ping"
{
  // ...
  responses: {
    200: {
      description: "Success",
        schema: {
          type: "string",
          example: "pong"
        }
     }
  }
  // ...
}
```

At present, a definition like below generates `Primitive<any>` return value.
This PR handles such a case.