### PR TITLE
fix: generated type of multiple number enums are not separated

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^0.18.0",
-    "swagger-axios-codegen": "^0.3.3",
+    "swagger-axios-codegen": "^0.3.4",
     "typescript": "2.9.1"
   },
   "scripts": {

--- a/example/swagger.json
+++ b/example/swagger.json
@@ -480,6 +480,19 @@
             ],
             "type": "integer"
           }
+        },
+        "bar": {
+          "type": "array",
+          "items": {
+            "format": "int32",
+            "enum": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "type": "integer"
+          }
         }
       }
     },

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -5,6 +5,7 @@
 axios@^0.18.0:
   version "0.18.0"
   resolved "http://registry.npm.taobao.org/axios/download/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
+  integrity sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=
   dependencies:
     follow-redirects "^1.3.0"
     is-buffer "^1.1.5"
@@ -12,38 +13,46 @@ axios@^0.18.0:
 camelcase@^5.0.0:
   version "5.0.0"
   resolved "http://registry.npm.taobao.org/camelcase/download/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
+  integrity sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==
 
 debug@^3.1.0:
   version "3.1.0"
   resolved "http://registry.npm.taobao.org/debug/download/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   dependencies:
     ms "2.0.0"
 
 follow-redirects@^1.3.0:
   version "1.5.0"
   resolved "http://registry.npm.taobao.org/follow-redirects/download/follow-redirects-1.5.0.tgz#234f49cf770b7f35b40e790f636ceba0c3a0ab77"
+  integrity sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==
   dependencies:
     debug "^3.1.0"
 
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "http://registry.npm.taobao.org/is-buffer/download/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
 ms@2.0.0:
   version "2.0.0"
   resolved "http://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
+  integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
 prettier@^1.15.2:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.2.tgz#d31abe22afa4351efa14c7f8b94b58bb7452205e"
+  integrity sha512-YgPLFFA0CdKL4Eg2IHtUSjzj/BWgszDHiNQAe0VAIBse34148whfdzLagRL+QiKS+YfK5ftB6X4v/MBw8yCoug==
 
-swagger-axios-codegen@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/swagger-axios-codegen/-/swagger-axios-codegen-0.3.3.tgz#5ae0373246ad5f1830a2b31751fb3913cd76ba30"
+swagger-axios-codegen@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/swagger-axios-codegen/-/swagger-axios-codegen-0.3.4.tgz#986c1ab3b2133a3689e2359e8eb4587843e3d2da"
+  integrity sha512-i1tI7pl0Bg7BOhdiUoktVi2IOScsnAqIzsKrI0P3siUCz4djtxNh4QTckO2I03/ylmBMgJLcWRQnUJyN+2ge7Q==
   dependencies:
     axios "^0.18.0"
     camelcase "^5.0.0"
@@ -53,3 +62,4 @@ swagger-axios-codegen@^0.3.3:
 typescript@2.9.1:
   version "2.9.1"
   resolved "http://registry.npm.taobao.org/typescript/download/typescript-2.9.1.tgz#fdb19d2c67a15d11995fd15640e373e09ab09961"
+  integrity sha512-h6pM2f/GDchCFlldnriOhs1QHuwbnmj6/v7499eMHqPeW4V2G0elua2eIc2nu8v2NdHV0Gm+tzX83Hr6nUFjQA==

--- a/src/definitionCodegen/createDefinitionClass.ts
+++ b/src/definitionCodegen/createDefinitionClass.ts
@@ -40,7 +40,7 @@ export function createDefinitionClass(
     if (isType) {
       let typeName = `I${className}${pascalcase(k)}`
       enums.push({
-        name: typeName, text: `type ${typeName} = ${propType}`
+        name: typeName, text: `type ${typeName} = ${propType};`
       })
       propType = isArray ? typeName + '[]' : typeName
       ref = typeName


### PR DESCRIPTION
fix: generated type of multiple number enums are not separated
and updated example to show the error in the current version