### PR TITLE
Pascal case classnames

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "codegen"
   ],
   "scripts": {
-    "build": "tsc -p ./src",
+    "build": "tsc",
     "prestart": "npm run build",
     "precommit": "prettier --write --config .prettierrc ./src/*.ts",
     "start": "node ./dist/index",
@@ -30,7 +30,6 @@
     "prettier": "^1.15.2"
   },
   "devDependencies": {
-    "@types/camelcase": "^4.1.0",
     "@types/node": "^9.6.0",
     "@types/prettier": "^1.12.2",
     "tslint": "^5.10.0",

--- a/src/requestCodegen/getRequestParameters.ts
+++ b/src/requestCodegen/getRequestParameters.ts
@@ -1,8 +1,8 @@
-import { IParameter } from "../swaggerInterfaces";
+import { IParameter } from '../swaggerInterfaces'
 
-import { refClassName, toBaseType } from "../utils";
+import { refClassName, toBaseType } from '../utils'
 
-import camelcase = require("camelcase");
+import camelcase from 'camelcase'
 
 /**
  * 生成参数

--- a/src/requestCodegen/index.ts
+++ b/src/requestCodegen/index.ts
@@ -1,16 +1,17 @@
 import { getMethodName } from '../utils'
 import { IPaths } from '../swaggerInterfaces'
-import { getRequestParameters } from './getRequestParameters';
-import { getResponseType } from './getResponseType';
+import { getRequestParameters } from './getRequestParameters'
+import { getResponseType } from './getResponseType'
+import camelcase from 'camelcase'
 
 export interface IRequestClass {
-  [key: string]: IRequestMethods[]
+  [key: string]: IRequestMethods[];
 }
 
 interface IRequestMethods {
-  name: string,
-  operationId: string,
-  requestSchema: any
+  name: string;
+  operationId: string;
+  requestSchema: any;
 }
 
 export function requestCodegen(paths: IPaths): IRequestClass {
@@ -19,16 +20,17 @@ export function requestCodegen(paths: IPaths): IRequestClass {
   for (const [path, request] of Object.entries(paths)) {
     let methodName = getMethodName(path)
     for (const [method, reqProps] of Object.entries(request)) {
-
       // methodName = options.methodNameMode === 'operationId' ? reqProps.operationId : methodName
       const contentType =
-        reqProps.consumes && reqProps.consumes.includes('multipart/form-data') ? 'multipart/form-data' : 'application/json'
+        reqProps.consumes && reqProps.consumes.includes('multipart/form-data')
+          ? 'multipart/form-data'
+          : 'application/json'
       let formData = ''
       let pathReplace = ''
       // 获取类名
-      if (!reqProps.tags) continue;
-      const className = reqProps.tags[0].replace(/s/g, '')
-      if (className === '') continue;
+      if (!reqProps.tags) continue
+      const className = camelcase(reqProps.tags[0], { pascalCase: true })
+      if (className === '') continue
       // 是否存在
       if (!requestClasses[className]) {
         requestClasses[className] = []
@@ -40,11 +42,12 @@ export function requestCodegen(paths: IPaths): IRequestClass {
         // 获取到接口的参数
         parsedParameters = getRequestParameters(reqProps.parameters)
 
-        parameters = parsedParameters.requestParameters.length > 0
-          ? `params: {
+        parameters =
+          parsedParameters.requestParameters.length > 0
+            ? `params: {
               ${parsedParameters.requestParameters}
           } = <any>{},`
-          : ''
+            : ''
 
         formData = parsedParameters.requestFormData ? 'data = new FormData();\n' + parsedParameters.requestFormData : ''
         pathReplace = parsedParameters.requestPathReplace

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,4 +1,4 @@
-import camelcase = require("camelcase");
+import camelcase from 'camelcase'
 import { IPropDef } from "./baseInterfaces";
 
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
             "./typings",
             "./typings/camelcase",
             "./node_modules/@types"
-        ]
+        ],
+        "outDir": "dist"
     },
     "files": ["src/index.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "sourceMap": true,
+        "target": "es2017" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+        "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */   
+        "esModuleInterop":true,
+        "noImplicitAny": false,
+        "typeRoots": [
+            "./typings",
+            "./typings/camelcase",
+            "./node_modules/@types"
+        ]
+    },
+    "files": ["src/index.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,6 @@
 # yarn lockfile v1
 
 
-"@types/camelcase@^4.1.0":
-  version "4.1.0"
-  resolved "http://registry.npm.taobao.org/@types/camelcase/download/@types/camelcase-4.1.0.tgz#e054f7986f31658d49936261b5cd4588ef29d1ee"
-
 "@types/node@^9.6.0":
   version "9.6.18"
   resolved "http://registry.npm.taobao.org/@types/node/download/@types/node-9.6.18.tgz#092e13ef64c47e986802c9c45a61c1454813b31d"


### PR DESCRIPTION
Hi,

I solved the problem with class names (at least when using `path` parameter) mentioned in #13 .

The main issue is that type definitions for camelcase are *wrong* (or out of date, so at least currently wrong). Using a rx, as you did, is not effective.

The following is a more correct definition for [camelcase](https://github.com/sindresorhus/camelcase). You can compare against the library docs and [the "official" types definition](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/camelcase/index.d.ts) which is completely wrong.

```ts
declare interface ICamelCaseOptions{
    pascalCase: boolean
}

declare function camelcase(args: string| string[], options?: ICamelCaseOptions): string;
```

But i didn't have success in including into the local definitions, so I just decided to cut the official ones out.
I removed `@types/camelcase` and I added a `tsconfig.json` for handling this, which also address debugging issues (lack of sourcemaps in the generated code)