### PR TITLE
WIP: Add class-transformer to transform results and support dates

### DIFF
--- a/src/baseInterfaces.ts
+++ b/src/baseInterfaces.ts
@@ -14,12 +14,17 @@ export interface ISwaggerOptions {
   strictNullChecks?: boolean | undefined
   /** definition Class mode */
   modelMode?: 'class' | 'interface'
+  /** use class-transformer to transform the results */
+  useClassTransformer?: boolean
 }
 
 export interface IPropDef {
   name: string
   type: string
+  format?: string
   desc: string
+  isType: boolean
+  isEnum: boolean
 }
 
 export interface IInclude {

--- a/src/definitionCodegen/createDefinitionClass.ts
+++ b/src/definitionCodegen/createDefinitionClass.ts
@@ -45,7 +45,7 @@ export function createDefinitionClass(
       model.imports.push(ref)
     }
     // propsStr += classPropsTemplate(k, propType, v.description)
-    model.props.push({ name: k, type: propType, desc: v.description })
+    model.props.push({ name: k, type: propType, format: v.format, desc: v.description, isType, isEnum })
   }
   // : classTemplate(className, propsStr, constructorStr)
   return { enums, model }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,8 @@ const defaultOptions: ISwaggerOptions = {
   useCustomerRequestInstance: false,
   modelMode: 'interface',
   include: [],
-  strictNullChecks: true
+  strictNullChecks: true,
+  useClassTransformer: false,
 }
 
 
@@ -48,8 +49,8 @@ export async function codegen(params: ISwaggerOptions) {
     ...params
   }
   let apiSource = options.useCustomerRequestInstance
-    ? customerServiceHeader
-    : serviceHeader
+    ? customerServiceHeader(options)
+    : serviceHeader(options)
   // TODO: next next next time
   // if (options.multipleFileMode) {
   if (false) {
@@ -83,7 +84,7 @@ export async function codegen(params: ISwaggerOptions) {
     Object.values(models).forEach(item => {
       const text = params.modelMode === 'interface'
         ? interfaceTemplate(item.value.name, item.value.props, [], params.strictNullChecks)
-        : classTemplate(item.value.name, item.value.props, [], params.strictNullChecks)
+        : classTemplate(item.value.name, item.value.props, [], params.strictNullChecks, options.useClassTransformer)
       // const fileDir = path.join(options.outputDir || '', 'definitions')
       // writeFile(fileDir, item.name + '.ts', format(text, options))
       defsString += text
@@ -143,7 +144,7 @@ export async function codegen(params: ISwaggerOptions) {
       if (allImport.includes(item.name)) {
         const text = params.modelMode === 'interface'
           ? interfaceTemplate(item.value.name, item.value.props, [], params.strictNullChecks)
-          : classTemplate(item.value.name, item.value.props, [], params.strictNullChecks)
+          : classTemplate(item.value.name, item.value.props, [], params.strictNullChecks, options.useClassTransformer)
         defSource += text
       }
     })
@@ -181,7 +182,7 @@ export async function codegen(params: ISwaggerOptions) {
       Object.values(models).forEach(item => {
         const text = params.modelMode === 'interface'
           ? interfaceTemplate(item.value.name, item.value.props, [], params.strictNullChecks)
-          : classTemplate(item.value.name, item.value.props, [], params.strictNullChecks)
+          : classTemplate(item.value.name, item.value.props, [], params.strictNullChecks, options.useClassTransformer)
         apiSource += text
       })
 

--- a/src/requestCodegen/getResponseType.ts
+++ b/src/requestCodegen/getResponseType.ts
@@ -22,6 +22,7 @@ export function getResponseType(reqProps: IRequestMethod): { responseType: strin
   }
 
   let checkType = resSchema.type
+  let format = resSchema.format;
   // 如果是数组
   if (checkType === 'array' || resSchema.items) {
     if (resSchema.items.$ref) {
@@ -29,7 +30,7 @@ export function getResponseType(reqProps: IRequestMethod): { responseType: strin
       isRef = true
       result = refType + '[]'
     } else {
-      const refType = toBaseType(resSchema.type)
+      const refType = toBaseType(resSchema.type, resSchema.format)
       result = refType + '[]'
     }
   } else if (resSchema.$ref) {
@@ -37,8 +38,9 @@ export function getResponseType(reqProps: IRequestMethod): { responseType: strin
     result = refClassName(resSchema.$ref) || 'any'
     isRef = true
   } else {
+    console.log(checkType + " " + format);
     result = checkType
-    result = toBaseType(result)
+    result = toBaseType(result, format)
   }
 
   if (result == 'object') {

--- a/src/requestCodegen/getResponseType.ts
+++ b/src/requestCodegen/getResponseType.ts
@@ -38,7 +38,6 @@ export function getResponseType(reqProps: IRequestMethod): { responseType: strin
     result = refClassName(resSchema.$ref) || 'any'
     isRef = true
   } else {
-    console.log(checkType + " " + format);
     result = checkType
     result = toBaseType(result, format)
   }

--- a/src/requestCodegen/getResponseType.ts
+++ b/src/requestCodegen/getResponseType.ts
@@ -30,7 +30,7 @@ export function getResponseType(reqProps: IRequestMethod): { responseType: strin
       isRef = true
       result = refType + '[]'
     } else {
-      const refType = toBaseType(resSchema.type, resSchema.format)
+      const refType = toBaseType(resSchema.items.type, resSchema.items.format)
       result = refType + '[]'
     }
   } else if (resSchema.$ref) {

--- a/src/swaggerInterfaces.ts
+++ b/src/swaggerInterfaces.ts
@@ -30,6 +30,7 @@ export interface IRequestMethod {
         '$ref': string,
         'type'?: string,
         'items'?: IParameterItems,
+        'format'?: string,
       }
     }
   }

--- a/src/swaggerInterfaces.ts
+++ b/src/swaggerInterfaces.ts
@@ -61,6 +61,7 @@ export interface IParameterSchema {
 
 export interface IParameterItems {
   type?: string
+  format?: string
   $ref: string
   items?: IParameterItems
 }

--- a/src/template.ts
+++ b/src/template.ts
@@ -54,9 +54,8 @@ export function classPropsTemplate(filedName: string, type: string, format: stri
    *   //description 
    *   fieldName: type
    */
-  const decorators = useClassTransformer ? classTransformTemplate(type, format, isType) : '';
-
   type = toBaseType(type, format);
+  const decorators = useClassTransformer ? classTransformTemplate(type, format, isType) : '';
 
   return `
   /** ${description || ''} */
@@ -114,7 +113,6 @@ export function requestTemplate(name: string, requestSchema: IRequestSchema, opt
     parsedParameters = <any>{},
     formData = ''
   } = requestSchema
-
   const { useClassTransformer } = options;
   const { queryParameters = [], bodyParameters = [] } = parsedParameters
   const nonArrayType = responseType.replace('[', '').replace(']', '');

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,5 +1,8 @@
 import camelcase from 'camelcase'
-import { IPropDef } from "./baseInterfaces";
+import { IPropDef, ISwaggerOptions } from "./baseInterfaces";
+import { toBaseType } from './utils';
+
+const baseTypes = ['string', 'number', 'object', 'boolean', 'any'];
 
 /** 类模板 */
 export function interfaceTemplate(name: string, props: IPropDef[], imports: string[], strictNullChecks: boolean = true) {
@@ -13,24 +16,29 @@ export function interfaceTemplate(name: string, props: IPropDef[], imports: stri
 
   export interface ${name} {
 
-    ${props.map(p => classPropsTemplate(p.name, p.type, p.desc, !strictNullChecks)).join('')}
+    ${props.map(p => classPropsTemplate(p.name, p.type, null, p.desc, !strictNullChecks, false, false)).join('')}
   }
   `
 }
 
 /** 类模板 */
-export function classTemplate(name: string, props: IPropDef[], imports: string[], strictNullChecks: boolean = true) {
+export function classTemplate(name: string, props: IPropDef[], imports: string[], strictNullChecks: boolean = true, useClassTransformer: boolean) {
   // 所有的引用
-  const importString = imports.map(imp => {
+  const mappedImports = imports.map(imp => {
     return `import { ${imp} } from '../definitions/${imp}'\n`
-  }).join('')
+  })
+
+  if (useClassTransformer && imports.length > 0) {
+    mappedImports.push(`import { Type, Transform, Expose } from 'class-transformer'\n`)
+  }
+  const importString = mappedImports.join('');
 
   return `
   ${importString}
 
   export class ${name} {
 
-    ${props.map(p => classPropsTemplate(p.name, p.type, p.desc, !strictNullChecks)).join('')}
+    ${props.map(p => classPropsTemplate(p.name, p.type, p.format, p.desc, !strictNullChecks, useClassTransformer, p.isEnum || p.isType)).join('')}
 
     constructor(data: (undefined | any) = {}){
         ${props.map(p => classConstructorTemplate(p.name)).join('')}
@@ -40,17 +48,31 @@ export function classTemplate(name: string, props: IPropDef[], imports: string[]
 }
 
 /** 类属性模板 */
-export function classPropsTemplate(filedName: string, type: string, description: string, canNull: boolean) {
+export function classPropsTemplate(filedName: string, type: string, format: string, description: string, canNull: boolean, useClassTransformer: boolean, isType: boolean) {
   /**
    * eg: 
    *   //description 
    *   fieldName: type
    */
+  const decorators = useClassTransformer ? classTransformTemplate(type, format, isType) : '';
+
+  type = toBaseType(type, format);
 
   return `
   /** ${description || ''} */
+  ${decorators}
   ${filedName}${canNull ? '?' : ''}:${type};
   `
+}
+
+export function classTransformTemplate(type: string, format: string, isType: boolean) {
+  const decorators: string[] = [`@Expose()`];
+  const nonArrayType = type.replace('[', '').replace(']', '');
+  /* ignore interfaces */
+  if (baseTypes.indexOf(nonArrayType) < 0 && !isType) {
+    decorators.push(`@Type(() => ${nonArrayType})`);
+  }
+  return decorators.join('\n');
 }
 
 /** 类属性模板 */
@@ -93,8 +115,12 @@ export function requestTemplate(name: string, requestSchema: IRequestSchema, opt
     formData = ''
   } = requestSchema
 
+  const { useClassTransformer } = options;
   const { queryParameters = [], bodyParameters = [] } = parsedParameters
-
+  const nonArrayType = responseType.replace('[', '').replace(']', '');
+  const isArrayType = responseType.indexOf('[') > 0;
+  const transform = useClassTransformer && baseTypes.indexOf(nonArrayType) < 0;
+  const resolveString = transform ? `(response: any${isArrayType ? '[]' : ''}) => resolve(plainToClass(${nonArrayType}, response, {strategy: 'excludeAll'}))` : 'resolve';
   return `
 /**
  * ${summary || ''}
@@ -114,7 +140,7 @@ ${options.useStaticMethod ? 'static' : ''} ${camelcase(name)}(${parameters}optio
     }
     ${contentType === 'multipart/form-data' ? formData : ''}
     configs.data = data;
-    axios(configs, resolve, reject)
+    axios(configs, ${resolveString}, reject);
   });
 }`;
 }
@@ -128,90 +154,101 @@ export function serviceTemplate(name: string, body: string) {
   `
 }
 
-export const serviceHeader = `/** Generate by swagger-axios-codegen */
+export const serviceHeader = (options: ISwaggerOptions) => {
+  const classTransformerImport = options.useClassTransformer
+    ? `import { Expose, Transform, Type, plainToClass } from 'class-transformer';
+  ` : '';
 
-import axiosStatic, { AxiosPromise, AxiosInstance } from 'axios';
-export interface IRequestOptions {
-  headers?: any;
-  baseURL?: string;
-}
+  return `/** Generate by swagger-axios-codegen */
 
-interface IRequestConfig {
-  method?: any;
-  headers?: any;
-  url?: any;
-  data?: any;
-  params?: any;
-}
+  import axiosStatic, { AxiosPromise, AxiosInstance } from 'axios';
+  ${classTransformerImport}
 
-// Add options interface
-export interface ServiceOptions {
-  axios?: AxiosInstance,
-}
+  export interface IRequestOptions {
+    headers?: any;
+    baseURL?: string;
+  }
 
-// Add default options
-export const serviceOptions: ServiceOptions = {
-};
+  interface IRequestConfig {
+    method?: any;
+    headers?: any;
+    url?: any;
+    data?: any;
+    params?: any;
+  }
 
-// Instance selector
-function axios(configs: IRequestConfig, resolve: (p: any) => void, reject: (p: any) => void) {
-  const req = serviceOptions.axios ? serviceOptions.axios.request(configs) : axiosStatic(configs);
+  // Add options interface
+  export interface ServiceOptions {
+    axios?: AxiosInstance,
+  }
 
-  return req.then((res) => { resolve(res.data); }).catch(err => { reject(err); });
-}
-
-function getConfigs(method: string, contentType: string, url: string,options: any):IRequestConfig {
-  const configs: IRequestConfig = { ...options, method, url };
-  configs.headers = {
-    ...options.headers,
-    'Content-Type': contentType,
+  // Add default options
+  export const serviceOptions: ServiceOptions = {
   };
-  return configs
-}
-`
 
-export const customerServiceHeader = `/** Generate by swagger-axios-codegen */
+  // Instance selector
+  function axios(configs: IRequestConfig, resolve: (p: any) => void, reject: (p: any) => void) {
+    const req = serviceOptions.axios ? serviceOptions.axios.request(configs) : axiosStatic(configs);
 
-export interface IRequestOptions {
-  headers?: any;
-}
+    return req.then((res) => { resolve(res.data); }).catch(err => { reject(err); });
+  }
 
-interface IRequestPromise<T=any> extends Promise<IRequestResponse<T>> {}
-
-interface IRequestResponse<T=any> {
-  data: T;
-  status: number;
-  statusText: string;
-  headers: any;
-  config: any;
-  request?: any;
+  function getConfigs(method: string, contentType: string, url: string,options: any):IRequestConfig {
+    const configs: IRequestConfig = { ...options, method, url };
+    configs.headers = {
+      ...options.headers,
+      'Content-Type': contentType,
+    };
+    return configs
+  }
+  `
 }
 
-interface IRequestInstance {
-  (config: any): IRequestPromise;
-  (url: string, config?: any): IRequestPromise;
-  request<T = any>(config: any): IRequestPromise<T>;
-}
+export const customerServiceHeader = (options: ISwaggerOptions) => {
 
-interface IRequestConfig {
-  method?: any;
-  headers?: any;
-  url?: any;
-  data?: any;
-  params?: any;
-}
+  return `/** Generate by swagger-axios-codegen */
 
-// Add options interface
-export interface ServiceOptions {
-  axios?: IRequestInstance,
-}
+  export interface IRequestOptions {
+    headers?: any;
+  }
 
-// Add default options
-export const serviceOptions: ServiceOptions = {
-};
+  interface IRequestPromise<T=any> extends Promise<IRequestResponse<T>> {}
 
-// Instance selector
-function axios(configs: IRequestConfig): IRequestPromise {
-  return serviceOptions.axios && serviceOptions.axios.request(configs);
+  interface IRequestResponse<T=any> {
+    data: T;
+    status: number;
+    statusText: string;
+    headers: any;
+    config: any;
+    request?: any;
+  }
+
+  interface IRequestInstance {
+    (config: any): IRequestPromise;
+    (url: string, config?: any): IRequestPromise;
+    request<T = any>(config: any): IRequestPromise<T>;
+  }
+
+  interface IRequestConfig {
+    method?: any;
+    headers?: any;
+    url?: any;
+    data?: any;
+    params?: any;
+  }
+
+  // Add options interface
+  export interface ServiceOptions {
+    axios?: IRequestInstance,
+  }
+
+  // Add default options
+  export const serviceOptions: ServiceOptions = {
+  };
+
+  // Instance selector
+  function axios(configs: IRequestConfig): IRequestPromise {
+    return serviceOptions.axios && serviceOptions.axios.request(configs);
+  }
+  `
 }
-`

--- a/src/template.ts
+++ b/src/template.ts
@@ -159,18 +159,13 @@ export const serviceHeader = (options: ISwaggerOptions) => {
 
   return `/** Generate by swagger-axios-codegen */
   import axiosStatic, { AxiosPromise, AxiosInstance } from 'axios';
-  export interface IRequestOptions {
-    headers?: any;
-    baseURL?: string;
-    responseType?: string;
-  }
 
-  import axiosStatic, { AxiosPromise, AxiosInstance } from 'axios';
   ${classTransformerImport}
 
   export interface IRequestOptions {
     headers?: any;
     baseURL?: string;
+    responseType?: string;
   }
 
   interface IRequestConfig {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,7 +33,7 @@ export function refClassName(s: string) {
   }
 }
 
-export function toBaseType(s: string) {
+export function toBaseType(s: string, format?: string) {
   if (s === undefined || s === null || s.length === 0) {
     return 'any | null'
   }
@@ -55,7 +55,14 @@ export function toBaseType(s: string) {
     case 'Guid':
     case 'String':
     case 'string':
-      result = 'string'
+      switch (format) {
+        case 'date':
+        case 'date-time':
+          result = 'Date';
+          break
+        default:
+          result = 'string';
+      }
       break
     case 'file':
       result = 'any'


### PR DESCRIPTION
This MR adds https://github.com/typestack/class-transformer to transform the result types. Strings, which have the a format of `date` or `date-time` are now transformed to a `Date` instance.

The default option used for class-transformer is to ignore all additional parameters. So the transformed result Object only contains the parameters defined inside the DTO or generated model and additional parameters returned by the API are ignored.

There is an option to enable class-transformer which is `false` by default and therefore it does not break any existing usage.