### PR TITLE
fix: enum member cannot have numeric value

### DIFF
--- a/src/definitionCodegen/propTrueType.ts
+++ b/src/definitionCodegen/propTrueType.ts
@@ -39,7 +39,12 @@ export function propTrueType(v: IDefinitionProperty): {
   // 是枚举 并且是字符串类型
   else if (v.enum && v.type === 'string') {
     result.isEnum = true
-    result.propType = getEnums(v.enum).map(item => `'${item}'='${item}'`).join(',')
+    result.propType = getEnums(v.enum).map(item => {
+      if (isNaN(item)){
+        return `'${item}'='${item}'`;
+      }
+      return  `'KEY_${item}'='${item}'`;
+      }).join(',')
   }
   else if (v.enum) {
     result.isType = true


### PR DESCRIPTION
## Motivation 

When we got an enum like this in definitions : 

``` json
 "ResponseEntity": {
      "type": "object",
      "properties": {
        "body": { "type": "object" },
        "statusCode": {
          "type": "string",
          "enum": [
            "100",
            "101",
          ]
        },
        "statusCodeValue": { "type": "integer", "format": "int32" }
      },
      "title": "ResponseEntity"
    },
``` 

code generation will generate an enum like this 
``` ts
export enum EnumResponseEntityStatusCode {
  '100' = '100',
  '101' = '101'
}
``` 

Triggering a .ts error `An enum member cannot have a numeric name.`


## Test Plan 

The project builds and it worked for me in local. I don't have a test plan as there is no unitary tests in this package

## Related issue

#64 