### PR TITLE
Error: The "path" argument must be of type string. Received type undefined

### DIFF
--- a/src/templates/serviceHeader.ts
+++ b/src/templates/serviceHeader.ts
@@ -118,15 +118,13 @@ function requestHeader() {
 
 function definitionHeader(fileDir: string | undefined) {
   let fileStr = '// empty '
-  console.log('extendDefinitionFile url : ', path.resolve(fileDir))
   if (!!fileDir) {
-
+    console.log('extendDefinitionFile url : ', path.resolve(fileDir))
     if (fs.existsSync(path.resolve(fileDir))) {
       const buffs = fs.readFileSync(path.resolve(fileDir))
       fileStr = buffs.toString('utf8')
     }
   }
-
 
   return `
   ${universalGenericTypeDefinition()}


### PR DESCRIPTION
(node:9880) UnhandledPromiseRejectionWarning: TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type undefined
    at validateString (internal/validators.js:112:11)
    at Object.resolve (path.js:139:9)
    at definitionHeader (C:\Code\swagger-axios-codegen\dist\templates\serviceHeader.js:124:53)
    at Object.serviceHeader (C:\Code\swagger-axios-codegen\dist\templates\serviceHeader.js:44:5)
    at C:\Code\swagger-axios-codegen\dist\index.js:71:127