### PR TITLE
Bug OpenApi3 Missing Property Types

### DIFF
--- a/src/componentsCodegen/propTrueType.ts
+++ b/src/componentsCodegen/propTrueType.ts
@@ -12,16 +12,16 @@ export function propTrueType(v: IDefinitionProperty): {
     isType: false,
     ref: ''
   }
-  if (v.$ref) {
+  if (v.$ref || (v.allOf && v.allOf[0])) {
     // 是引用类型
-    result.propType = refClassName(v.$ref)
+    result.propType = refClassName(v.$ref || v.allOf[0].$ref)
     result.ref = result.propType
   }
   //是个数组
   else if (v.items) {
-    if (v.items.$ref) {
+    if (v.items.$ref || (v.items.allOf && v.items.allOf[0])) {
       // 是个引用类型
-      result.ref = refClassName(v.items.$ref)
+      result.ref = refClassName(v.items.$ref || v.items.allOf[0].$ref)
       result.propType = result.ref + '[]'
     } else {
       if (v.items.type === "array") {

--- a/src/swaggerInterfaces.ts
+++ b/src/swaggerInterfaces.ts
@@ -110,6 +110,7 @@ export interface IDefinitionProperty {
   format: string
   maxLength: number
   $ref: string
+  allOf: IDefinitionProperties
   items: IDefinitionProperty
   description: string
 }


### PR DESCRIPTION
Found a bug in v3. Some of property types were missing.

![Screenshot_17](https://user-images.githubusercontent.com/13495631/72860727-a00f5180-3cbf-11ea-8208-5d4e4565b368.png)

Reference to the documentation [allOf](https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/#allof)