### PR TITLE
fix: pass format value for modeMode: "interface", which was null #80

### DIFF
--- a/src/templates/template.ts
+++ b/src/templates/template.ts
@@ -23,7 +23,7 @@ export function interfaceTemplate(
 
   export interface ${name} {
 
-    ${props.map(p => classPropsTemplate(p.name, p.type, null, p.desc, !strictNullChecks, false, false)).join('')}
+    ${props.map(p => classPropsTemplate(p.name, p.type, p.format, p.desc, !strictNullChecks, false, false)).join('')}
   }
   `
 }


### PR DESCRIPTION
When using `modelMode: "interface"` the `format` value from swagger always passed `null` into the `classPropsTemplate` function. It now correctly passes `p.format`.

For example, this will ensure that `format: date` will be transformed to `Date` and not `string`.

Fixes #80 