### PR TITLE
fix: mergining imports

### DIFF
--- a/src/requestCodegen/index.ts
+++ b/src/requestCodegen/index.ts
@@ -59,7 +59,7 @@ export function requestCodegen(paths: IPaths, isV3: boolean, options: ISwaggerOp
 
         // 合并imports
         if (parsedParameters.imports) {
-          imports.push(parsedRequestBody.imports)
+          imports.push(...parsedRequestBody.imports)
         }
 
         parsedParameters.requestParameters = parsedParameters.requestParameters


### PR DESCRIPTION
Merging the imports of the parameters and the body for a request pushed the body imports inside the imports array instead of adding it's elements. This way there was an array inside an array and at a later point, where the name is checked, it fails because it is an array and not a string