### PR TITLE
fix multipart request when no query params

### DIFF
--- a/src/requestCodegen/index.ts
+++ b/src/requestCodegen/index.ts
@@ -52,7 +52,7 @@ export function requestCodegen(paths: IPaths, isV3: boolean, options: ISwaggerOp
 
         if (reqProps.parameters || multipartDataProperties) {
           // 获取到接口的参数
-          let tempParameters = reqProps.parameters
+          let tempParameters = reqProps.parameters || []
 
           // 合并两个参数类型
           if (multipartDataProperties) {


### PR DESCRIPTION
requestCodegen/index.ts
In case reqProps.parameters == null (no other query params)- an exception in concat occurs
![image](https://user-images.githubusercontent.com/16288249/84373431-3bf51780-abe5-11ea-84b0-f73bd9f3aef7.png)
