### PR TITLE
feature: add useHeaderParameters option

### DIFF
--- a/src/baseInterfaces.ts
+++ b/src/baseInterfaces.ts
@@ -30,6 +30,8 @@ export interface ISwaggerOptions {
   urlFilters?: string[] | null | undefined
   /** shared service options to multiple service*/
   sharedServiceOptions?: boolean | undefined
+  /** use parameters in header or not*/
+  useHeaderParameters: boolean
 }
 
 export interface IPropDef {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,8 @@ const defaultOptions: ISwaggerOptions = {
   useClassTransformer: false,
   extendGenericType: [],
   multipleFileMode: false,
-  sharedServiceOptions: false
+  sharedServiceOptions: false,
+  useHeaderParameters: false
 }
 
 /** main */

--- a/src/requestCodegen/getRequestParameters.ts
+++ b/src/requestCodegen/getRequestParameters.ts
@@ -7,15 +7,16 @@ import camelcase from 'camelcase'
 /**
  * 参数去重
  * 后台书写不规范,存在参数重名的情况
- * @param params 
+ * @param params
  */
 function getUniqParams(params: IParameter[]): IParameter[] {
   const uniqParams: Record<string, IParameter> = {}
   params.forEach(v => {
     // _${v.in}
     // TODO:同名但是v.in= query |path |body 的情况同时出现如何处理？分出不同的request参数？
-    if (!v.name.includes('[0]')) { //DTO class中存在List<T>时会出现这种参数 (list[0].prop)
-      uniqParams[`${v.name}`] = v;
+    if (!v.name.includes('[0]')) {
+      //DTO class中存在List<T>时会出现这种参数 (list[0].prop)
+      uniqParams[`${v.name}`] = v
     }
   })
   return Object.values(uniqParams)
@@ -32,6 +33,7 @@ export function getRequestParameters(params: IParameter[]) {
   let requestPathReplace = ''
   let queryParameters: string[] = []
   let bodyParameters: string[] = []
+  let headerParameters: string[] = []
   let imports: string[] = []
   let moreBodyParams = params.filter(item => item.in === 'body').length > 1
   params.forEach(p => {
@@ -85,8 +87,18 @@ export function getRequestParameters(params: IParameter[]) {
       //     : `...params['${paramName}']`
       //   : `'${p.name}':params['${paramName}']`
       bodyParameters.push(body)
+    } else if (p.in === 'header') {
+      headerParameters.push(`'${p.name}':params['${paramName}']`)
     }
   })
   const bodyParameter = moreBodyParams ? `{${bodyParameters.join(',')}}` : bodyParameters.join(',')
-  return { requestParameters, requestFormData, requestPathReplace, queryParameters, bodyParameter, imports }
+  return {
+    requestParameters,
+    requestFormData,
+    requestPathReplace,
+    queryParameters,
+    bodyParameter,
+    headerParameters,
+    imports
+  }
 }

--- a/src/requestCodegen/getRequestParameters.ts
+++ b/src/requestCodegen/getRequestParameters.ts
@@ -26,7 +26,7 @@ function getUniqParams(params: IParameter[]): IParameter[] {
  * 生成参数
  * @param params
  */
-export function getRequestParameters(params: IParameter[]) {
+export function getRequestParameters(params: IParameter[], useHeaderParameters: boolean) {
   params = getUniqParams(params)
   let requestParameters = ''
   let requestFormData = ''
@@ -37,6 +37,8 @@ export function getRequestParameters(params: IParameter[]) {
   let imports: string[] = []
   let moreBodyParams = params.filter(item => item.in === 'body').length > 1
   params.forEach(p => {
+    // 根据设置跳过请求头中的参数
+    if (!useHeaderParameters && p.in === 'header') return
     let propType = ''
     // 引用类型定义
     if (p.schema) {

--- a/src/requestCodegen/index.ts
+++ b/src/requestCodegen/index.ts
@@ -26,11 +26,15 @@ export function requestCodegen(paths: IPaths, isV3: boolean, options: ISwaggerOp
     for (const [path, request] of Object.entries(paths)) {
       let methodName = getMethodName(path)
       for (const [method, reqProps] of Object.entries(request)) {
-        methodName = options.methodNameMode === 'operationId' ? reqProps.operationId : 			
-          options.methodNameMode === 'shortOperationId' ? trimSuffix(reqProps.operationId, reqProps.tags?.[0]) : methodName
+        methodName =
+          options.methodNameMode === 'operationId'
+            ? reqProps.operationId
+            : options.methodNameMode === 'shortOperationId'
+            ? trimSuffix(reqProps.operationId, reqProps.tags?.[0])
+            : methodName
         if (!methodName) {
           // console.warn('method Name is null：', path);
-          continue;
+          continue
         }
         const contentType = getContentType(reqProps, isV3)
         let formData = ''
@@ -60,7 +64,7 @@ export function requestCodegen(paths: IPaths, isV3: boolean, options: ISwaggerOp
             tempParameters = tempParameters.concat(mapFormDataToV2(multipartDataProperties.schema))
           }
 
-          parsedParameters = getRequestParameters(tempParameters)
+          parsedParameters = getRequestParameters(tempParameters, options.useHeaderParameters)
           formData = parsedParameters.requestFormData
             ? 'data = new FormData();\n' + parsedParameters.requestFormData
             : ''
@@ -82,9 +86,7 @@ export function requestCodegen(paths: IPaths, isV3: boolean, options: ISwaggerOp
           parsedParameters.requestParameters = parsedParameters.requestParameters
             ? parsedParameters.requestParameters + parsedRequestBody.bodyType
             : parsedRequestBody.bodyType
-
         }
-
 
         parameters =
           parsedParameters.requestParameters?.length > 0

--- a/src/swaggerInterfaces.ts
+++ b/src/swaggerInterfaces.ts
@@ -60,7 +60,7 @@ export interface IRequestBody {
   }
 }
 
-export type IParameterIn = 'path' | 'formData' | 'query' | 'body'
+export type IParameterIn = 'path' | 'formData' | 'query' | 'body' | 'header'
 
 export interface IParameter {
   in: IParameterIn

--- a/src/templates/template.ts
+++ b/src/templates/template.ts
@@ -191,7 +191,7 @@ export function requestTemplate(name: string, requestSchema: IRequestSchema, opt
     requestBody = null
   } = requestSchema
   const { useClassTransformer } = options
-  const { queryParameters = [], bodyParameter = [] } = parsedParameters
+  const { queryParameters = [], bodyParameter = [], headerParameters } = parsedParameters
   const nonArrayType = responseType.replace('[', '').replace(']', '')
   const isArrayType = responseType.indexOf('[') > 0
   const transform = useClassTransformer && baseTypes.indexOf(nonArrayType) < 0
@@ -211,6 +211,9 @@ ${options.useStaticMethod ? 'static' : ''} ${camelcase(
   return new Promise((resolve, reject) => {
     let url = '${path}'
     ${pathReplace}
+    ${parsedParameters && headerParameters && headerParameters.length > 0
+      ? `options.headers = {${headerParameters}, ...options.headers }`
+      : ''}
     const configs:IRequestConfig = getConfigs('${method}', '${contentType}', url, options)
     ${parsedParameters && queryParameters.length > 0 ? 'configs.params = {' + queryParameters.join(',') + '}' : ''}
     let data = ${


### PR DESCRIPTION
起因：在目前项目使用过程中有一些参数在请求头中 而且为必填项
目前的版本会将这些参数加入到请求接口的参数类型中
然而实际上并没有将这些参数加入到axios的请求headers中 此处为一bug

另外工作中请求头中的参数大部分都为固定参数 
所以使用新建axios实例来初始化headers中的参数，和README中展示的一样
所以在设置中增加了一个useHeaderParameters设置项
用来控制请求头中的参数是否进入接口的参数列表

目前headers的覆盖顺序为 {...requestParametersHeaders, ...requestOptionsHeaders, 'Content-type':XXX}

做了一些简单的测试，功能已经实现。
如还有遗漏的地方麻烦帮忙补充或者讨论。

（有几行的修改是由于Prettier格式导致的，如单行超过80字符，自动进行格式化了）