### PR TITLE
fix: numeric enum keys are always prefixed with `KEY_`

### DIFF
--- a/src/componentsCodegen/createDefinitionEnum.ts
+++ b/src/componentsCodegen/createDefinitionEnum.ts
@@ -7,15 +7,12 @@ import { IEnumDef } from "../baseInterfaces";
  * @param type 枚举的类型
  */
 export function createDefinitionEnum(className: string, enumArray: any[], type: string): IEnumDef {
-  let result = ''
-  if (type === 'string') {
-    result = enumArray.map(item => `'${item}'='${item}'`).join(',')
-  }
-  else {
-    result = type === 'string' ?
-      enumArray.map(item => `'${item}'`).join('|') :
-      enumArray.join('|')
-  }
-
+  const result = type === 'string'
+    ? enumArray
+      .map(item => Number.isNaN(item)
+        ? `'${item}'='${item}'`
+        : `'KEY_${item}'='${item}'`)
+      .join(',')
+    : enumArray.join('|')
   return { name: className, enumProps: result, type: type }
 }

--- a/src/componentsCodegen/propTrueType.ts
+++ b/src/componentsCodegen/propTrueType.ts
@@ -53,7 +53,12 @@ export function propTrueType(v: IDefinitionProperty): {
   // 是枚举 并且是字符串类型
   else if (v.enum && v.type === 'string') {
     result.isEnum = true
-    result.propType = getEnums(v.enum).map(item => `'${item}'='${item}'`).join(',')
+    result.propType = getEnums(v.enum)
+      .map(item =>
+        isNaN(item)
+          ? `'${item}'='${item}'`
+          : `'KEY_${item}'='${item}'`)
+      .join(',')
   }
   else if (v.enum) {
     result.isType = true

--- a/src/definitionCodegen/createDefinitionEnum.ts
+++ b/src/definitionCodegen/createDefinitionEnum.ts
@@ -7,15 +7,12 @@ import { IEnumDef } from "../baseInterfaces";
  * @param type 枚举的类型
  */
 export function createDefinitionEnum(className: string, enumArray: any[], type: string): IEnumDef {
-  let result = ''
-  if (type === 'string') {
-    result = enumArray.map(item => `'${item}'='${item}'`).join(',')
-  }
-  else {
-    result = type === 'string' ?
-      enumArray.map(item => `'${item}'`).join('|') :
-      enumArray.join('|')
-  }
-
+  const result = type === 'string'
+    ? enumArray
+      .map(item => Number.isNaN(item)
+        ? `'${item}'='${item}'`
+        : `'KEY_${item}'='${item}'`)
+      .join(',')
+    : enumArray.join('|')
   return { name: className, enumProps: result, type: type }
 }

--- a/src/definitionCodegen/propTrueType.ts
+++ b/src/definitionCodegen/propTrueType.ts
@@ -39,12 +39,12 @@ export function propTrueType(v: IDefinitionProperty): {
   // 是枚举 并且是字符串类型
   else if (v.enum && v.type === 'string') {
     result.isEnum = true
-    result.propType = getEnums(v.enum).map(item => {
-      if (isNaN(item)){
-        return `'${item}'='${item}'`;
-      }
-      return  `'KEY_${item}'='${item}'`;
-      }).join(',')
+    result.propType = getEnums(v.enum)
+      .map(item =>
+        isNaN(item)
+          ? `'${item}'='${item}'`
+          : `'KEY_${item}'='${item}'`)
+      .join(',')
   }
   else if (v.enum) {
     result.isType = true


### PR DESCRIPTION
relates to https://github.com/Manweill/swagger-axios-codegen/pull/65

Problem: spec definition contained the following schema:

```js
{
  "ReportSchema": {
    "properties": {
      "errorCode": {
        "description": "Error code",
        "enum": [
          "10",
          "20",
          "30",
          "40"
        ],
        "example": "10",
        "maxLength": 3,
        "type": "string"
      }
    }
  }
}
```

The output was not a valid TS:

```ts
export enum ReportSchemaErrorCode {
  '10' = '10',
  '20' = '20',
  '30' = '30',
  '40' = '40'
}
```

Enum keys in TS cannot be numeric.

The PR#65 fixed one of the 4 places with the enum generation. This PR fixes the other three places.

Output with this PR:

```ts
export enum ReportSchemaErrorCode {
  'KEY_10' = '10',
  'KEY_20' = '20',
  'KEY_30' = '30',
  'KEY_40' = '40'
}
```