### PR TITLE
add support for custom method name mode

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -14,6 +14,7 @@
     "build:gen": "node ./swagger/codegen.js",
     "build:api": "npm run clean && node ./swagger/codegen.js && npm run build",
     "build:api-shortOperationId": "npm run clean && node ./swagger/codegen-shortOperationId.js && npm run build",
+    "build:api-customMethodNameMode": "npm run clean && node ./swagger/codegen-customMethodNameMode.js && npm run build",
     "build:api-include": "node ./swagger/codegen.include.js && npm run build",
     "build:api3": "node ./swagger/codegen.v3.js && npm run build",
     "build": "tsc -p ./swagger"

--- a/example/swagger/codegen-customMethodNameMode.js
+++ b/example/swagger/codegen-customMethodNameMode.js
@@ -1,0 +1,17 @@
+const { codegen } = require('../../dist/index.js')
+
+codegen({
+  methodNameMode: (reqProps) => {
+    let camelCaseSplit = reqProps.operationId
+      .replace(/([a-z])([A-Z])/g, "$1 $2")
+      .split(" ");
+    return camelCaseSplit.slice(0, -1).join("");
+  },
+  source: require('../swagger-operationId.json'),
+  outputDir: './swagger/services',
+  strictNullChecks: false,
+  modelMode: 'interface',
+  extendDefinitionFile: './swagger/customerDefinition.ts',
+  extendGenericType: ['JsonResult'],
+  sharedServiceOptions: true
+})

--- a/src/baseInterfaces.ts
+++ b/src/baseInterfaces.ts
@@ -1,7 +1,9 @@
+import { IRequestMethod } from './swaggerInterfaces'
+
 export interface ISwaggerOptions {
   serviceNameSuffix?: string
   enumNamePrefix?: string
-  methodNameMode?: 'operationId' | 'path' | 'shortOperationId'
+  methodNameMode?: 'operationId' | 'path' | 'shortOperationId' | ((reqProps: IRequestMethod) => string)
   outputDir?: string
   fileName?: string
   remoteUrl?: string

--- a/src/requestCodegen/index.ts
+++ b/src/requestCodegen/index.ts
@@ -31,6 +31,8 @@ export function requestCodegen(paths: IPaths, isV3: boolean, options: ISwaggerOp
             ? reqProps.operationId
             : options.methodNameMode === 'shortOperationId'
             ? trimSuffix(reqProps.operationId, reqProps.tags?.[0])
+            : typeof options.methodNameMode === 'function'
+            ? options.methodNameMode(reqProps)
             : methodName
         if (!methodName) {
           // console.warn('method Name is null：', path);


### PR DESCRIPTION
### Problem

I'm currently using [nestjs/swagger](https://github.com/nestjs/swagger) for building an API and the autogenerated `operationId` comes with not only the tag at the end but also the controller name.

**Example:** `PostsController.getMany` (Tag: Posts) => `getManyPostsControllerPosts`

#108 implemented a solution for removing the first tag from the `operationId` but I still needed the controller name to be removed.

**Generated with `shortOperationId`:** `getManyPostsController`

So I'm suggesting this change to make possible to use custom method name mode (a function) so you can implement your own.

### Solution

Using a custom method name mode:

```js
  methodNameMode: (reqProps) => {
    let camelCaseSplit = reqProps.operationId
      .replace(/([a-z])([A-Z])/g, "$1 $2")
      .split(" ");
    return camelCaseSplit.slice(0, -3).join("");
  },
```

**Example:** `PostsController.getMany` (Tag: Posts) => `getManyPostsControllerPosts`
**Generated with custom method name mode**: `getMany`

I'm able to remove the last 3 words that appear on the `operationId`. Not ideal when you have controllers or tags with more than one word, but if you have something like that you're still able to come up with your own solution for generating the method name.