### PR TITLE
fix: don't exclude props of untransformed props

### DIFF
--- a/src/templates/template.ts
+++ b/src/templates/template.ts
@@ -205,7 +205,7 @@ export function requestTemplate(name: string, requestSchema: IRequestSchema, opt
   const transform = useClassTransformer && baseTypes.indexOf(nonArrayType) < 0
   const resolveString = transform
     ? `(response: any${isArrayType ? '[]' : ''
-    }) => resolve(plainToClass(${nonArrayType}, response, {strategy: 'excludeAll'}))`
+    }) => resolve(plainToClass(${nonArrayType}, response))`
     : 'resolve'
 
   return `


### PR DESCRIPTION
Hi @Manweill ,

Thanks for the fix of https://github.com/Manweill/swagger-axios-codegen/issues/128

Unfortunately the remaining issue is that all props that are not transformed with class-transformer are not decorated with `@Expose()`. Meaning that this props will be accessed as `undefined` by the app because they will be excluded.

I updated the template so that this does not happen but maybe you'll come with a better solution.

Thanks.

Ronan