### PR TITLE
ignore unused import

### DIFF
--- a/src/templates/serviceHeader.ts
+++ b/src/templates/serviceHeader.ts
@@ -11,6 +11,7 @@ export function serviceHeader(options: ISwaggerOptions) {
   return `/** Generate by swagger-axios-codegen */
   // tslint:disable
   /* eslint-disable */
+  // @ts-ignore
   import axiosStatic, { AxiosInstance } from 'axios';
 
   ${classTransformerImport}


### PR DESCRIPTION
Looks like `axiosStatic` isn't being used, should it be removed? If it is I'll be happy to update this PR.
My project tsconfig.json has this rule set to true: `"noUnusedLocals": true` so it throws error: axiosStatic is declared but its value is never read. The quick fix is to add `// @ts-ignore` right above the import line.