### PR TITLE
add quotes string fallback to typeTemplate when typeString is an an empty string

### DIFF
--- a/src/templates/template.ts
+++ b/src/templates/template.ts
@@ -172,7 +172,7 @@ export function enumTemplate(name: string, enumString: string, prefix?: string) 
 
 export function typeTemplate(name: string, typeString: string, prefix?: string) {
   return `
-  export type ${name} = ${typeString};
+  export type ${name} = ${typeString || '""'};
   `
 }
 


### PR DESCRIPTION
Hi there,

I am using an OpenAPI3 schema generated by  DRF-Spectecular for Django. In our swagger.json we have an Enum with an empty string value. 

Our BlankEnum field on the schema:

```json
            "BlankEnum": {
                "enum": [
                    ""
                ]
            },
```

This causes the generator to write faulty TS code:

```
error SyntaxError: Type expected. (5103:27)
> 5103 |   export type BlankEnum = ;
       |                           ^
```

My current fix is to change the template.ts to render an empty string with quotes and it seems to work, as the generator will do write an emtpy string with quotes in the generated TS code.

```typescript
export function typeTemplate(name: string, typeString: string, prefix?: string) {
  return `
  export type ${name} = ${typeString || '""'};
  `
}
```

If this change is acceptable feel free to merge, would be great. Keep up the good work and cheers.