### PR TITLE
Bugfix/required and nullable difference

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ export interface ISwaggerOptions {
   /** custom function to format the output file (default: prettier.format()) **/
   format?: (s: string) => string
   /** match with tsconfig */
+  strictRequiredChecks?: boolean | undefined
+  /** match with tsconfig */
   strictNullChecks?: boolean | undefined
   /** definition Class mode */
   modelMode?: 'class' | 'interface'
@@ -86,6 +88,7 @@ const defaultOptions: ISwaggerOptions = {
   useStaticMethod: true,
   useCustomerRequestInstance: false,
   include: [],
+  strictRequiredChecks: true,
   strictNullChecks: true,
   /** definition Class mode ,auto use interface mode to streamlined code*/
   modelMode?: 'interface'

--- a/example/swagger/codegen-customMethodNameMode.js
+++ b/example/swagger/codegen-customMethodNameMode.js
@@ -1,4 +1,4 @@
-const { codegen } = require('../../dist/index.js')
+const { codegen } = require('../../dist/index.js');
 
 codegen({
   methodNameMode: (reqProps) => {
@@ -9,9 +9,10 @@ codegen({
   },
   source: require('../swagger-operationId.json'),
   outputDir: './swagger/services',
+  strictRequiredChecks: false,
   strictNullChecks: false,
   modelMode: 'interface',
   extendDefinitionFile: './swagger/customerDefinition.ts',
   extendGenericType: ['JsonResult'],
   sharedServiceOptions: true
-})
+});

--- a/example/swagger/codegen-shortOperationId.js
+++ b/example/swagger/codegen-shortOperationId.js
@@ -1,12 +1,13 @@
-const { codegen } = require('../../dist/index.js')
+const { codegen } = require('../../dist/index.js');
 
 codegen({
   methodNameMode: 'shortOperationId',
   source: require('../swagger-operationId.json'),
   outputDir: './swagger/services',
+  strictRequiredChecks: false,
   strictNullChecks: false,
   modelMode: 'interface',
   extendDefinitionFile: './swagger/customerDefinition.ts',
   extendGenericType: ['JsonResult'],
   sharedServiceOptions: true
-})
+});

--- a/example/swagger/codegen.generic.js
+++ b/example/swagger/codegen.generic.js
@@ -1,5 +1,5 @@
 // const { codegen } = require('swagger-axios-codegen')
-const { codegen } = require('../../dist/index.js')
+const { codegen } = require('../../dist/index.js');
 
 codegen({
   methodNameMode: 'path',
@@ -7,6 +7,7 @@ codegen({
   // remoteUrl: 'http://localhost:44307/swagger/v1/swagger.json',
   outputDir: './swagger/services',
   fileName: 'indexGeneric.ts',
+  strictRequiredChecks: false,
   strictNullChecks: false,
   modelMode: 'interface'
-})
+});

--- a/example/swagger/codegen.include.js
+++ b/example/swagger/codegen.include.js
@@ -1,5 +1,5 @@
 // const { codegen } = require('swagger-axios-codegen')
-const { codegen } = require('../../dist/index.js')
+const { codegen } = require('../../dist/index.js');
 
 let include = [
   // "products-test",
@@ -11,12 +11,13 @@ let include = [
   // 'Products*',
   '!Products',
   { 'User': ['*', '!history'] },
-]
+];
 codegen({
   methodNameMode: 'path',
+  strictRequiredChecks: false,
   strictNullChecks: false,
   modelMode: 'interface',
   source: require('../swagger.json'),
   outputDir: './swagger/services',
   include
-})
+});

--- a/example/swagger/codegen.js
+++ b/example/swagger/codegen.js
@@ -1,15 +1,16 @@
 // const { codegen } = require('swagger-axios-codegen')
-const { codegen } = require('../../dist/index.js')
+const { codegen } = require('../../dist/index.js');
 
 codegen({
   methodNameMode: 'path',
   source: require('../swagger.json'),
   // remoteUrl: 'http://localhost:44307/swagger/v1/swagger.json',
   outputDir: './swagger/services',
+  strictRequiredChecks: false,
   strictNullChecks: false,
   // useCustomerRequestInstance: true,
   modelMode: 'interface',
   extendDefinitionFile: './swagger/customerDefinition.ts',
   extendGenericType: ['JsonResult'],
   sharedServiceOptions: true
-})
+});

--- a/example/swagger/codegen.v3.js
+++ b/example/swagger/codegen.v3.js
@@ -1,5 +1,5 @@
 // const { codegen } = require('swagger-axios-codegen')
-const { codegen } = require('../../dist/index.js')
+const { codegen } = require('../../dist/index.js');
 
 codegen({
   methodNameMode: 'path',
@@ -7,6 +7,7 @@ codegen({
   // remoteUrl: 'http://localhost:44307/swagger/v1/swagger.json',
   outputDir: './swagger/services',
   fileName: 'indexv3.ts',
+  strictRequiredChecks: false,
   strictNullChecks: false,
   modelMode: 'interface'
-})
+});

--- a/src/baseInterfaces.ts
+++ b/src/baseInterfaces.ts
@@ -15,6 +15,8 @@ export interface ISwaggerOptions {
   includeTypes?: Array<string>
   format?: (s: string) => string
   /** match with tsconfig */
+  strictRequiredChecks?: boolean | undefined
+  /** match with tsconfig */
   strictNullChecks?: boolean | undefined
   /** definition Class mode */
   modelMode?: 'class' | 'interface'

--- a/src/index.filter.ts
+++ b/src/index.filter.ts
@@ -79,11 +79,12 @@ function codegenInclude(
     if (allImport.includes(item.name)) {
       const text =
         options.modelMode === 'interface'
-          ? interfaceTemplate(item.value.name, item.value.props, [], options.strictNullChecks)
+          ? interfaceTemplate(item.value.name, item.value.props, [], options.strictRequiredChecks, options.strictNullChecks)
           : classTemplate(
             item.value.name,
             item.value.props,
             [],
+            options.strictRequiredChecks,
             options.strictNullChecks,
             options.useClassTransformer,
             options.generateValidationModel
@@ -225,11 +226,12 @@ function codegenMultimatchInclude(
     if (allImport.includes(item.name)) {
       const text =
         options.modelMode === 'interface'
-          ? interfaceTemplate(item.value.name, item.value.props, [], options.strictNullChecks)
+          ? interfaceTemplate(item.value.name, item.value.props, [], options.strictRequiredChecks, options.strictNullChecks)
           : classTemplate(
             item.value.name,
             item.value.props,
             [],
+            options.strictRequiredChecks,
             options.strictNullChecks,
             options.useClassTransformer,
             options.generateValidationModel

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ const defaultOptions: ISwaggerOptions = {
   modelMode: 'interface',
   include: [],
   includeTypes: [],
+  strictRequiredChecks: true,
   strictNullChecks: true,
   useClassTransformer: false,
   extendGenericType: [],
@@ -139,11 +140,12 @@ export async function codegen(params: ISwaggerOptions) {
     Object.values(models).forEach(item => {
       const text =
         params.modelMode === 'interface'
-          ? interfaceTemplate(item.value.name, item.value.props, [], params.strictNullChecks)
+          ? interfaceTemplate(item.value.name, item.value.props, [], params.strictRequiredChecks, params.strictNullChecks)
           : classTemplate(
             item.value.name,
             item.value.props,
             [],
+            params.strictRequiredChecks,
             params.strictNullChecks,
             options.useClassTransformer,
             options.generateValidationModel
@@ -219,11 +221,12 @@ function codegenAll(
     Object.values(models).forEach(item => {
       const text =
         options.modelMode === 'interface'
-          ? interfaceTemplate(item.value.name, item.value.props, [], options.strictNullChecks)
+          ? interfaceTemplate(item.value.name, item.value.props, [], options.strictRequiredChecks, options.strictNullChecks)
           : classTemplate(
             item.value.name,
             item.value.props,
             [],
+            options.strictRequiredChecks,
             options.strictNullChecks,
             options.useClassTransformer,
             options.generateValidationModel
@@ -313,11 +316,12 @@ function codegenInclude(
     if (allImport.includes(item.name) || options.includeTypes.includes(item.name)) {
       const text =
         options.modelMode === 'interface'
-          ? interfaceTemplate(item.value.name, item.value.props, [], options.strictNullChecks)
+          ? interfaceTemplate(item.value.name, item.value.props, [], options.strictRequiredChecks, options.strictNullChecks)
           : classTemplate(
             item.value.name,
             item.value.props,
             [],
+            options.strictRequiredChecks,
             options.strictNullChecks,
             options.useClassTransformer,
             options.generateValidationModel
@@ -459,11 +463,12 @@ function codegenMultimatchInclude(
     if (allImport.includes(item.name) || options.includeTypes.includes(item.name)) {
       const text =
         options.modelMode === 'interface'
-          ? interfaceTemplate(item.value.name, item.value.props, [], options.strictNullChecks)
+          ? interfaceTemplate(item.value.name, item.value.props, [], options.strictRequiredChecks, options.strictNullChecks)
           : classTemplate(
             item.value.name,
             item.value.props,
             [],
+            options.strictRequiredChecks,
             options.strictNullChecks,
             options.useClassTransformer,
             options.generateValidationModel

--- a/src/swaggerInterfaces.ts
+++ b/src/swaggerInterfaces.ts
@@ -107,6 +107,8 @@ export interface IDefinitionProperty {
   type: string
   enum: any[]
   format: string
+  readOnly: boolean
+  nullable: boolean
   maxLength: number
   $ref: string
   allOf: IDefinitionProperty[]

--- a/src/templates/template.ts
+++ b/src/templates/template.ts
@@ -29,15 +29,19 @@ export function interfaceTemplate(
 
   export interface ${name} {
 
-    ${props.map(p => classPropsTemplate(
-    p.name,
-    p.type,
-    p.format,
-    p.desc,
-    (!strictNullChecks || !(p.validationModel as any)?.required) && !isAdditionalProperties(p.name),
-    false,
-    false
-  )).join('')}
+    ${props.map(p => {
+      const validationModel = p.validationModel as any;
+      return classPropsTemplate(
+        p.name,
+        p.type,
+        p.format,
+        p.desc,
+        (validationModel?.required && !validationModel?.readOnly) && !isAdditionalProperties(p.name),
+        (!strictNullChecks || validationModel?.nullable) && !isAdditionalProperties(p.name),
+        false,
+        false
+      )
+    }).join('')}
   }
   `
 }
@@ -67,16 +71,19 @@ export function classTemplate(
   export class ${name} {
 
     ${props
-      .map(p =>
-        classPropsTemplate(
-          p.name,
-          p.type,
-          p.format,
-          p.desc,
-          !strictNullChecks || !(p.validationModel as any)?.required,
-          useClassTransformer,
-          p.isEnum || p.isType,
-        )
+      .map(p => {
+          const validationModel = p.validationModel as any;
+          return classPropsTemplate(
+            p.name,
+            p.type,
+            p.format,
+            p.desc,
+            (validationModel?.required && !validationModel?.readOnly) && !isAdditionalProperties(p.name),
+            (!strictNullChecks || validationModel?.nullable) && !isAdditionalProperties(p.name),
+            false,
+            false
+          )
+        }
       )
       .join('')}
 
@@ -94,6 +101,7 @@ export function classPropsTemplate(
   type: string,
   format: string,
   description: string,
+  isRequired: boolean,
   canNull: boolean,
   useClassTransformer: boolean,
   isType: boolean
@@ -113,12 +121,12 @@ export function classPropsTemplate(
     return `
   /** ${description || ''} */
   ${decorators}
-  ${filedName}${canNull ? '?' : ''}:${type};
+  ${filedName}${!isRequired ? '?' : ''}:${type}${canNull === true ? ' | null' : ''};
   `
   } else {
     return `
   /** ${description || ''} */
-  ${filedName}${canNull ? '?' : ''}:${type};
+  ${filedName}${!isRequired ? '?' : ''}:${type}${canNull === true ? ' | null' : ''};
   `
   }
 }

--- a/src/templates/template.ts
+++ b/src/templates/template.ts
@@ -11,6 +11,7 @@ export function interfaceTemplate(
   name: string,
   props: IPropDef[],
   imports: string[],
+  strictRequiredChecks: boolean = true,
   strictNullChecks: boolean = true
 ) {
   if (isDefinedGenericTypes(name)) {
@@ -36,7 +37,7 @@ export function interfaceTemplate(
         p.type,
         p.format,
         p.desc,
-        (validationModel?.required && !validationModel?.readOnly) && !isAdditionalProperties(p.name),
+        ((!strictRequiredChecks) || validationModel?.required && !validationModel?.readOnly) && !isAdditionalProperties(p.name),
         (!strictNullChecks || validationModel?.nullable) && !isAdditionalProperties(p.name),
         false,
         false
@@ -51,6 +52,7 @@ export function classTemplate(
   name: string,
   props: IPropDef[],
   imports: string[],
+  strictRequiredChecks: boolean = true,
   strictNullChecks: boolean = true,
   useClassTransformer: boolean,
   generateValidationModel: boolean
@@ -78,7 +80,7 @@ export function classTemplate(
             p.type,
             p.format,
             p.desc,
-            (validationModel?.required && !validationModel?.readOnly) && !isAdditionalProperties(p.name),
+            ((!strictRequiredChecks) || validationModel?.required && !validationModel?.readOnly) && !isAdditionalProperties(p.name),
             (!strictNullChecks || validationModel?.nullable) && !isAdditionalProperties(p.name),
             false,
             false

--- a/src/templates/template.ts
+++ b/src/templates/template.ts
@@ -172,7 +172,7 @@ export function enumTemplate(name: string, enumString: string, prefix?: string) 
 
 export function typeTemplate(name: string, typeString: string, prefix?: string) {
   return `
-  export type ${name} = ${typeString};
+  export type ${name} = ${typeString || '""'};
   `
 }
 

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -27,6 +27,7 @@
     /* Strict Type-Checking Options */
     "strict": true, /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    "strictRequiredChecks": false, /* Enable strict required checks. */
     "strictNullChecks": false, /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -27,7 +27,6 @@
     /* Strict Type-Checking Options */
     "strict": true, /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    "strictRequiredChecks": false, /* Enable strict required checks. */
     "strictNullChecks": false, /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -280,5 +280,13 @@ export function getValidationModel(propName: string, prop: IDefinitionProperty, 
     validationModel.maxLength = prop.maxLength
     hasValidationRules = true
   }
+  if (prop.nullable) {
+    validationModel.nullable = prop.nullable
+    hasValidationRules = true
+  }
+  if (prop.readOnly) {
+    validationModel.readOnly = prop.readOnly
+    hasValidationRules = true
+  }
   return hasValidationRules ? validationModel : null
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
     /* Strict Type-Checking Options */
     "strict": true, /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    "strictRequiredChecks": false, /* Enable strict null checks. */
     "strictNullChecks": false, /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */


### PR DESCRIPTION
Hi there, 

We have found a problem concerning nullable fields which lead into more problems, if we are using `required`, `readOnly` and `nullabel` in combination.

To keep the possibility as before, `strictRequiredChecks` has been added.
- strictRequiredChecks will allow `undefined` values
- strictNullChecks will allow `null` values


We have implemented some changes:
- Extend the field props with the values for `nullable` and `readOnly`
- Changed the behavior of a field description based on these values (for undefined and null seperately)

A field is required when:
- The field property `readOnly` is false and property is `required` is true or `strictRequiredChecks` is false

A field is nullable when:
- The field property `nullable`  is true or `strictNullChecks` is false

These changes might break implementations of other developers, since `strictNullCheck` has been moved to the `nullable` evaluation instead `required` aka `undefined`.

Please let me know this poses a problem. Happy coding!