### PR TITLE
fix: expose string types without a format specification

### DIFF
--- a/src/templates/template.ts
+++ b/src/templates/template.ts
@@ -107,7 +107,7 @@ export function classPropsTemplate(
   if (isNotAdditionalProperties(filedName)) {
     filedName = `'${filedName}'`
   }
-  if (useClassTransformer && format) {
+  if (useClassTransformer) {
     const decorators = classTransformTemplate(type, format, isType)
 
     return `


### PR DESCRIPTION
It is **not** required for a type to carry an additional **format** spec.
We are trying to import a swagger API document which does not assign a specific format to its string typed attributes.

> Primitives have an **optional** modifier property: format.

see: https://swagger.io/specification/#data-types
see also table in spec stating that: `The formats defined by the OAS are: string without any format`