### PR TITLE
fix: Multipart Formdata bodies are ignored

### DIFF
--- a/src/templates/template.ts
+++ b/src/templates/template.ts
@@ -238,14 +238,8 @@ ${options.useStaticMethod ? 'static' : ''} ${camelcase(
 }
 
 function requestBodyString(method: string, parsedParameters: [], bodyParameter: [], requestBody: string, contentType: string, formData: string) {
-  if (parsedParameters && bodyParameter && bodyParameter.length > 0 || !!requestBody) {
-
-    const tips = `/** 适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body */ \n 
-    console.warn('适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body')`
+  if (method === 'post' || method === 'put') {
     return `
-    
-    ${method === 'post' || method === 'put' ? '' : tips}
-
     let data = ${parsedParameters && bodyParameter && bodyParameter.length > 0
         ?
         bodyParameter
@@ -256,7 +250,9 @@ function requestBodyString(method: string, parsedParameters: [], bodyParameter: 
     ${contentType === 'multipart/form-data' ? formData : ''}
     configs.data = data;`
   }
-  return ''
+  return `/** 适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body */ \n 
+  console.warn('适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body')
+  `
 }
 
 /** serviceTemplate */


### PR DESCRIPTION
Hi,

switching from 0.16.8 to 0.16.9 the generated client ignores file uploads. We have this request in swagger:
 
```
"requestBody": {
    "required": true,
    "content": {
        "multipart/form-data": {
            "schema": {
                "type": "object",
                "properties": {
                    "file": {
                        "type": "string",
                        "format": "binary"
                    }
                }
            }
        }
    }
}
```

which worked fine and generated the upload code:
<img width="632" alt="image" src="https://github.com/Manweill/swagger-axios-codegen/assets/7426376/49679ff9-a72e-48b8-be25-9b944dfd7047">

Since 0.16.9 it is broken and generated nothing in this place. This breaks the file uploads for us.

We identified the change which broke the generation. It seems that the if statement is to harsh and in our case it will be skipped. We made a PR to revert this if statement change, bur we are open for other solutions. 

https://github.com/Manweill/swagger-axios-codegen/compare/v0.16.8...v0.16.9