### PR TITLE
feat: 拓展AxiosRequestConfig定义能力

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ export interface ISwaggerOptions {
   sharedServiceOptions?: boolean | undefined
   /** use parameters in header or not*/
   useHeaderParameters?: boolean
+  /** wrapper response type */
+  responseTypeWrapper?: (responseType: string)=> string
+  /** wrapper IRequestOptions */
+  requestOptionsWrapper?: (IRequestOptionsStr: string)=> string
+  /** add an additional declaration before the IRequestOptions */
+  customDefinition?: string
 }
 
 const defaultOptions: ISwaggerOptions = {

--- a/example/swagger/codegen.js
+++ b/example/swagger/codegen.js
@@ -12,5 +12,10 @@ codegen({
   extendDefinitionFile: './swagger/customerDefinition.ts',
   extendGenericType: ['JsonResult'],
   sharedServiceOptions: true,
-  classNameMode: 'parentPath'
+  classNameMode: 'parentPath',
+  customDefinition: `type SecurityTye = 'md5' | 'sha1' | 'aes' | 'des'`,
+  requestOptionsWrapper: (str) => {
+    return str + `    retryCount?: number
+    security?: Record<string, SecurityTye>`
+  }
 })

--- a/src/baseInterfaces.ts
+++ b/src/baseInterfaces.ts
@@ -40,7 +40,11 @@ export interface ISwaggerOptions {
   /** use parameters in header or not*/
   useHeaderParameters?: boolean
   /** wrapper response type */
-  responseTypeWrapper ?: (responseType: string)=> string
+  responseTypeWrapper?: (responseType: string)=> string
+  /** wrapper IRequestOptions */
+  requestOptionsWrapper?: (IRequestOptionsStr: string)=> string
+  /** add an additional declaration before the IRequestOptions */
+  customDefinition?: string
 }
 
 export interface IPropDef {

--- a/src/templates/serviceHeader.ts
+++ b/src/templates/serviceHeader.ts
@@ -4,18 +4,24 @@ import { ISwaggerOptions } from '../baseInterfaces'
 import { abpGenericTypeDefinition, universalGenericTypeDefinition } from './genericTypeDefinitionTemplate'
 
 export function serviceHeader(options: ISwaggerOptions) {
+  const customDefinition = options.customDefinition || ''
+  const requestOptionsWrapper = options.requestOptionsWrapper || ((str)=> str)
   const classTransformerImport = options.useClassTransformer
     ? `import { Expose, Transform, Type, plainToClass } from 'class-transformer';
   `
     : ''
+  
   return `/** Generate by swagger-axios-codegen */
   /* eslint-disable */
   // @ts-nocheck
   import axiosStatic, { type AxiosInstance, type AxiosRequestConfig } from 'axios';
 
   ${classTransformerImport}
+  ${customDefinition}
 
   export interface IRequestOptions extends AxiosRequestConfig {
+  ${
+requestOptionsWrapper(`
     /**
      * show loading status
      */
@@ -25,14 +31,11 @@ export function serviceHeader(options: ISwaggerOptions) {
      */
     showError?: boolean;
     /**
-     * data security, extended fields are encrypted using the specified algorithm
-     */
-    security?: Record<string, 'md5' | 'sha1' | 'aes' | 'des'>;
-    /**
      * indicates whether Authorization credentials are required for the request
      * @default true
      */
-    withAuthorization?: boolean;
+    withAuthorization?: boolean;`
+  )}
   }
 
   export interface IRequestConfig {
@@ -64,12 +67,17 @@ export function disableLint() {
 }
 
 export function customerServiceHeader(options: ISwaggerOptions) {
+  const customDefinition = options.customDefinition || ''
+  const requestOptionsWrapper = options.requestOptionsWrapper || ((str)=> str)
   return `/** Generate by swagger-axios-codegen */
   // @ts-nocheck
   /* eslint-disable */
   import axiosStatic, { type AxiosInstance, type AxiosRequestConfig } from 'axios';
 
+  ${customDefinition}
   export interface IRequestOptions extends AxiosRequestConfig {
+  ${
+requestOptionsWrapper(`
     /**
      * show loading status
      */
@@ -79,14 +87,11 @@ export function customerServiceHeader(options: ISwaggerOptions) {
      */
     showError?: boolean;
     /**
-     * data security, extended fields are encrypted using the specified algorithm
-     */
-    security?: Record<string, 'md5' | 'sha1' | 'aes' | 'des'>;
-    /**
      * indicates whether Authorization credentials are required for the request
      * @default true
      */
-    withAuthorization?: boolean;
+    withAuthorization?: boolean;`
+  )}
   }
 
   export interface IRequestPromise<T=any> extends Promise<IRequestResponse<T>> {}


### PR DESCRIPTION
1、添加了 requestOptionsWrapper 和 customDefinition
2、向README文档添加了这两个参数的定义
3、example/swagger/codegen.js 中添加了这两个参数，并测试了是否能够正常生产 api 文件
4、移除了可变的security参数

附图：
![image](https://github.com/user-attachments/assets/9c7f2e70-292e-4f73-ab2f-6011482e3f84)
![image](https://github.com/user-attachments/assets/e11adb57-0e81-4096-8ef5-d384e047c964)

#197 
