### PR TITLE
feat: add remoteUrlAxiosConfig to pass custom axios options for remote URL fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ export interface ISwaggerOptions {
   outputDir?: string
   fileName?: string
   remoteUrl?: string
+  /** extra axios config for the remote url fetch request (url, responseType and httpsAgent are ignored) */
+  remoteUrlAxiosConfig?: Omit<AxiosRequestConfig, 'url' |  'responseType' | 'httpsAgent'>
   source?: any
   useStaticMethod?: boolean | undefined
   useCustomerRequestInstance?: boolean | undefined

--- a/src/baseInterfaces.ts
+++ b/src/baseInterfaces.ts
@@ -1,3 +1,4 @@
+import { AxiosRequestConfig } from 'axios'
 import { IRequestMethod } from './swaggerInterfaces'
 
 export interface ISwaggerOptions {
@@ -10,6 +11,7 @@ export interface ISwaggerOptions {
   outputDir?: string
   fileName?: string
   remoteUrl?: string
+  remoteUrlAxiosConfig?: Omit<AxiosRequestConfig, 'url' | 'responseType' | 'httpsAgent'>
   source?: any
   useStaticMethod?: boolean | undefined
   useCustomerRequestInstance?: boolean | undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ export async function codegen(params: ISwaggerOptions) {
   // 获取接口定义文件
   try {
     if (params.remoteUrl) {
-      const { data: swaggerJson } = await axios({ url: params.remoteUrl, responseType: 'text', httpsAgent: new https.Agent({ rejectUnauthorized: false }) })
+      const { data: swaggerJson } = await axios({ url: params.remoteUrl, responseType: 'text', httpsAgent: new https.Agent({ rejectUnauthorized: false }), ...params.remoteUrlAxiosConfig })
       if (Object.prototype.toString.call(swaggerJson) === '[object String]') {
         fs.writeFileSync(swaggerSpecFileName, swaggerJson)
         swaggerSource = require(path.resolve(swaggerSpecFileName))


### PR DESCRIPTION
## Summary

- Added `remoteUrlAxiosConfig` option to `ISwaggerOptions` to allow passing custom Axios request config when fetching the remote swagger/OpenAPI spec
- The config is spread into the internal axios call, with `url`, `responseType`, and `httpsAgent` excluded (as those are already added)

## Motivation

When the swagger spec is hosted behind authentication (e.g. a private API gateway or a service requiring Bearer tokens), there was no way to pass request headers. This change enables that use case:

```ts
codegen({
  remoteUrl: 'https://internal.api/swagger.json',
  remoteUrlAxiosConfig: {
    headers: {
      Authorization: 'Bearer <token>'
    }
  },
  // ...
})
```